### PR TITLE
FIX subprocess call for Windows

### DIFF
--- a/poetry_poems/picker/__init__.py
+++ b/poetry_poems/picker/__init__.py
@@ -60,12 +60,7 @@ class Picker(object):
 
     def start(self):
         if IS_TESTING:
-            data = json.dumps(
-                {
-                    "query": self.query,
-                    "envs": len(self.environments),
-                }
-            )
+            data = json.dumps({"query": self.query, "envs": len(self.environments),})
             raise SystemExit(data)
         return curses.wrapper(self._start)
 

--- a/poetry_poems/poetry.py
+++ b/poetry_poems/poetry.py
@@ -7,7 +7,11 @@ def PipedPopen(cmds, **kwargs):
     """ Helper Piped Process for drier code"""
     timeout = kwargs.pop("timeout", None)
     env = kwargs.pop("env", dict(os.environ))
-    proc = Popen(cmds, stdout=PIPE, stderr=PIPE, env=env, **kwargs)
+
+    # For Windows we must explicitly state that a command should be run as a
+    # shell command
+    run_as_shell = sys.platform == "win32"
+    proc = Popen(cmds, stdout=PIPE, stderr=PIPE, env=env, shell=run_as_shell, **kwargs)
     out, err = proc.communicate(timeout=timeout)
     output = out.decode().strip() or err.decode().strip()
     code = proc.returncode
@@ -23,10 +27,13 @@ def call_poetry_shell(cwd, envname="poetry-shell", timeout=None):
     stdout = PIPE if is_test else sys.stdout
     stderr = PIPE if is_test else sys.stderr
 
+    # For Windows we must explicitly state that a command should be run as a
+    # shell command
+    run_as_shell = sys.platform == "win32"
     proc = Popen(
         ["poetry", "shell"],
         cwd=cwd,
-        shell=False,
+        shell=run_as_shell,
         stdout=stdout,
         stderr=stderr,
         env=environ,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -30,13 +30,7 @@ def test_get_project_name(folder_name, expected):
 
 @pytest.mark.utils
 @pytest.mark.parametrize(
-    "query,num_results",
-    [
-        ("proj", 2),
-        ("proj1", 1),
-        ("o", 4),
-        ("zzz", 0),
-    ],
+    "query,num_results", [("proj", 2), ("proj1", 1), ("o", 4), ("zzz", 0),],
 )
 def test_get_query_matches(query, num_results, environments):
     rv = get_query_matches(environments, query)


### PR DESCRIPTION
The call made with subprocess.POpen all used shell=False. This works on
Linux and mac, but is an issue on Windows. In this case Windows expects
a full string to the executable. The code only provides a shell command,
and we should set shell=True for Windows.

This has the drawback, that if ever an explicit string command is used,
the logic needs to be refined.